### PR TITLE
Fixed src filepath for Windows

### DIFF
--- a/PhpNamespace.py
+++ b/PhpNamespace.py
@@ -22,8 +22,10 @@ class PhpNamespaceCommand(sublime_plugin.TextCommand):
 
 		pos = filename.find("/src/")
 		if (pos == -1):
-			sublime.error_message("No src/ folder in current filepath\n" + filename)
-			return
+			pos = filename.find("\src\\")
+			if (pos == -1):
+				sublime.error_message("No src/ folder in current filepath\n" + filename)
+				return
 
 		if (not filename.endswith(".php")):
 			sublime.error_message("No .php extension")


### PR DESCRIPTION
Windows filepath convention is separated by "\" char.
This PR fix the bug.
